### PR TITLE
Fix arbitrage stats do not store value in db

### DIFF
--- a/controller/arbitrage.js
+++ b/controller/arbitrage.js
@@ -562,8 +562,8 @@ class Arbitrage {
                         adr: trader,
                         fromToken, toToken,
                         fromAmount, toAmount,
-                        profit,
-                        trade
+                        profit, trade,
+                        txHash: tx.hash
                     })
                 }
             }

--- a/controller/arbitrage.js
+++ b/controller/arbitrage.js
@@ -563,7 +563,7 @@ class Arbitrage {
                         fromToken, toToken,
                         fromAmount, toAmount,
                         profit, trade,
-                        txHash: tx.hash
+                        txHash: tx.transactionHash
                     })
                 }
             }

--- a/controller/db.js
+++ b/controller/db.js
@@ -61,11 +61,11 @@ class DbCtrl {
         }
     }
 
-    async addArbitrage({adr, tokenFrom, tokenTo, amountFrom, amountTo, profit, trade, txHash}) {
+    async addArbitrage({adr, fromToken, toToken, fromAmount, toAmount, profit, trade, txHash}) {
         try {
             return await this.arbRepo.insert({
-                adr, tokenFrom, tokenTo,
-                amountFrom, amountTo, profit, trade,
+                adr, fromToken, toToken,
+                fromAmount, toAmount, profit, trade,
                 txHash
             })
         } catch (e) {

--- a/models/arbitrage.js
+++ b/models/arbitrage.js
@@ -7,12 +7,12 @@ export default class Arbitrage extends BaseModel {
             id INTEGER PRIMARY KEY,
             adr text,
             dateAdded datetime,
-            amountFrom text,
-            amountTo text,
-            tokenFrom text,
-            tokenTo text,
+            fromAmount decimal,
+            toAmount decimal,
+            fromToken text,
+            toToken text,
             trade text,
-            profit text,
+            profit decimal,
             txHash
             )`);
     }


### PR DESCRIPTION
Closes #62

Done. There was some confusion with the fields names and also with the types. Changed `fromAmount`, `toAmount` and `profit` to decimal. Added `txHash`. Tested and working great  