### PR TITLE
Fix liquidation and rollover not being stored in DB

### DIFF
--- a/controller/db.js
+++ b/controller/db.js
@@ -73,12 +73,14 @@ class DbCtrl {
         }
     }
 
-    async addRollover({loanId, txHash, adr}) {
+    async addRollover({loanId, txHash, rolloverAdr, rolledoverAdr, amount}) {
         try {
             return await this.rollRepo.insert({
                 loanId,
                 txHash,
-                rolloverAdr: adr
+                rolloverAdr,
+                rolledoverAdr,
+                amount
             });
         } catch (e) {
             console.log(e);

--- a/controller/db.js
+++ b/controller/db.js
@@ -73,14 +73,15 @@ class DbCtrl {
         }
     }
 
-    async addRollover({loanId, txHash, rolloverAdr, rolledoverAdr, amount}) {
+    async addRollover({loanId, txHash, rolloverAdr, rolledoverAdr, amount, pos}) {
         try {
             return await this.rollRepo.insert({
                 loanId,
                 txHash,
                 rolloverAdr,
                 rolledoverAdr,
-                amount
+                amount,
+                pos
             });
         } catch (e) {
             console.log(e);

--- a/controller/rollover.js
+++ b/controller/rollover.js
@@ -115,12 +115,15 @@ class Rollover {
                     const params = U.parseEventParams(logs[log].events);
                 
                     if (params && params.loanId) {
+                        //wrong -> update
+                        const pos = params.sourceToken === conf.testTokenRBTC.toLowerCase() ? 'long' : 'short';
                         await dbCtrl.addRollover({
                             loanId: params.loanId,  
                             txHash: receipt.transactionHash,
                             rolloverAdr: receipt.logs[0].address,
                             rolledoverAdr: params.borrower,
                             amount: Number(C.web3.utils.fromWei(params.sourceAmount, "Ether")).toFixed(6),
+                            pos
                         })
                     }
                 }

--- a/tests/test_rollover.js
+++ b/tests/test_rollover.js
@@ -91,7 +91,7 @@ describe('Contract', async () => {
             }
             console.log("start rollover");
             for(let i in rollover) {
-                const w = await Wallet.getWallet("rollover", 0.001, "rBtc");
+                const [w] = await Wallet.getWallet("rollover", 0.001, "rBtc");
                 let nonce = await C.web3.eth.getTransactionCount(w.adr.toLowerCase(), 'pending');
                 const r = await Rollover.rollover(rollover[i], w.adr.toLowerCase(), nonce);
                 console.log(r);


### PR DESCRIPTION
Liquidation is definitely working!

![image](https://user-images.githubusercontent.com/40721795/115867919-f5468f80-a43b-11eb-9714-33c4145f0b67.png)

For rollover I need a transaction hash of a successful rollover transaction.

What seem to be not working now is (again) liquidation profit calculation :see_no_evil: 

![image](https://user-images.githubusercontent.com/40721795/115867999-127b5e00-a43c-11eb-8ee2-5051ec9bef9f.png)
![image](https://user-images.githubusercontent.com/40721795/115868041-1e672000-a43c-11eb-9d2b-4bbf73129c6c.png)

Guess another PR
