### PR TITLE
Improve the approval script

### DIFF
--- a/util/approval.js
+++ b/util/approval.js
@@ -3,28 +3,18 @@
  * These approvals should be executed for every liquidator and arbitrage wallet once in order for liquidation or interacting with the 
  * Swap contract can work flawlessly
 */
-import Web3 from 'web3';
 import C from '../controller/contract';
 import W from '../secrets/accounts';
-import abiTestToken from '../config/abiTestToken';
-import abiRBTCWrapperProxy from '../config/abiRBTCWrapperProxy';
+import Util from '../util/helper';
 import conf from '../config/config';
-import wallets from '../secrets/accounts';
 
-const web3 = new Web3(conf.nodeProvider);
-const amount = C.web3.utils.toWei("1000000000", 'ether');
-
-//Add wallets to web3, so they are ready for sending transactions
-for(let w in wallets) for (let a of wallets[w]) {
-    let pKey = a.pKey?a.pKey:web3.eth.accounts.decrypt(a.ks, process.argv[3]).privateKey;
-    web3.eth.accounts.wallet.add(pKey);
-}
-
+const web3 = C.web3;
+const BN = web3.utils.BN;
+const MAX_UINT256 = new BN('2').pow(new BN('256')).sub(new BN('1'));
+const amount = MAX_UINT256;
+const amountThreshold = amount.div(new BN('10')).mul(new BN('9')); // 90% of uint256 might be enough
 const tokenAddresses = C.getAllTokenAddresses();
-
-setTimeout(()=> {
-approve();
-},2000);
+const maxPendingTransactions = 4;
 
 async function approve() {
     await approveLiquidatorWallets();
@@ -32,92 +22,129 @@ async function approve() {
     await approveRolloverWallets();
 }
 
-
 async function approveLiquidatorWallets() {
     console.log("start approving liquidator wallets")
 
-    for (let w in W.liquidator) {
-        const from = W.liquidator[w].adr.toLowerCase();
-        let approved;
-        let tokenContract;
-
-
+    for (let wallet of W.liquidator) {
+        const walletAddress = wallet.adr;
         for (let tokenContractAddress of tokenAddresses) {
-            if (tokenContractAddress === conf.wRbtcWrapper) tokenContract = new web3.eth.Contract(abiRBTCWrapperProxy, tokenContractAddress);
-
-            else tokenContract = new web3.eth.Contract(abiTestToken, tokenContractAddress);
-
-            //should approve the Sovryn contract to spend the token for the main account
-            console.log("approving " + from + " " + conf.sovrynProtocolAdr + " for " + amount + " " + C.getTokenSymbol(tokenContractAddress))
-            approved = await C.approveToken(tokenContract, from, conf.sovrynProtocolAdr, amount);
-            console.log(approved);
+            await approveToken(tokenContractAddress, walletAddress, conf.sovrynProtocolAdr);
         }
- 
-        //should approve the rBTC IToken contract to spend sUSD (doc) for the main account
-        //only needed for opening positions (tests)
-        //approved = await C.approveToken(C.contractTokenSUSD, from, conf.loanTokenRBTC, amount);
-        //console.log(approved);
-
-        //only needed for opening positions (tests)
-        //should approve the rBTC IToken contract to spend rBTC for the main account
-        //approved = await C.approveToken(C.contractTokenRBTC, from, conf.loanTokenRBTC, amount);
-        //console.log(approved);
-
-        //only needed for opening positions (tests)
-        //should approve the sUSD IToken contract to spend rBTC for the main account
-        //approved = await C.approveToken(C.contractTokenRBTC, from, conf.loanTokenSUSD, amount);
-        //console.log(approved);
-
-        //should approve the sUSD IToken contract to spend sUSD (doc) for the main account
-        //only needed for opening positions (tests)
-        //approved = await C.approveToken(C.contractTokenSUSD, from, conf.loanTokenSUSD, amount);
-        //console.log(approved);
     }
-    return;
 }
-
 
 async function approveArbitrageWallets() {
-    console.log("start approving arbitrage wallet")
+    console.log("start approving arbitrage wallets")
 
-    const from = W.arbitrage[0].adr.toLowerCase();
-    let approved;
-    let tokenContract;
-
-    for (let tokenContractAddress of tokenAddresses) {
-        if (tokenContractAddress.toLowerCase() === conf.wRbtcWrapper) tokenContract = new web3.eth.Contract(abiRBTCWrapperProxy, tokenContractAddress);
-        else tokenContract = new web3.eth.Contract(abiTestToken, tokenContractAddress);
-        
-        //should approve the swap network contract (conf.swapsImpl) to spend the token for the main account
-        console.log("approving " + from + " " + conf.sovrynProtocolAdr + " for " + amount + " " + C.getTokenSymbol(tokenContractAddress))
-        approved = await C.approveToken(tokenContract, from, conf.swapsImpl, amount);
-        console.log(approved);
-
-        if (tokenContractAddress.toLowerCase() !== conf.wRbtcWrapper) {
-            //should approve the wRBTC wrapper contract to spend the token for the main account
-            approved = await C.approveToken(tokenContract, from, conf.wRbtcWrapper, amount);
-            console.log(approved);
+    for (let wallet of W.arbitrage) {
+        const walletAddress = wallet.adr;
+        for (let tokenContractAddress of tokenAddresses) {
+            // approve both the AMM and RBTC proxy to spend the tokens
+            // in theory, RBTC proxy should be enough....
+            await approveToken(tokenContractAddress, walletAddress, conf.swapsImpl);
+            await approveToken(tokenContractAddress, walletAddress, conf.wRbtcWrapper);
         }
     }
 }
-
 
 async function approveRolloverWallets() {
     console.log("start approving rollover wallets")
 
-    for (let w in W.rollover) {
-        const from = W.rollover[w].adr.toLowerCase();
-        let approved;
-        let tokenContract;
-
+    for (let wallet of W.rollover) {
+        const walletAddress = wallet.adr;
         for (let tokenContractAddress of tokenAddresses) {
-            if (tokenContractAddress === conf.wRbtcWrapper) tokenContract = new web3.eth.Contract(abiRBTCWrapperProxy, tokenContractAddress);
-            else tokenContract = new web3.eth.Contract(abiTestToken, tokenContractAddress);
-
-            //should approve the Sovryn contract to spend the token for the main account
-            console.log("approving " + from + " " + conf.sovrynProtocolAdr + " for " + amount + " " + C.getTokenSymbol(tokenContractAddress))
-            approved = await C.approveToken(tokenContract, from, conf.sovrynProtocolAdr, amount);
-            console.log(approved);
+            await approveToken(tokenContractAddress, walletAddress, conf.sovrynProtocolAdr);
         }
     }
+}
+
+const alreadyApproved = {};
+let numPendingTransactions = 0;
+async function approveToken(tokenAddress, ownerAddress, spenderAddress) {
+    const tokenSymbol = C.getTokenSymbol(tokenAddress);
+    tokenAddress = tokenAddress.toLowerCase();
+    ownerAddress = ownerAddress.toLowerCase();
+    spenderAddress = spenderAddress.toLowerCase();
+    const cacheKey = `${tokenAddress}-${ownerAddress}-${spenderAddress}`;
+    if(alreadyApproved[cacheKey]) {
+        console.log(`already approved ${spenderAddress} to spend ${tokenSymbol} on behalf of ${ownerAddress}`);
+        return;
+    }
+    alreadyApproved[cacheKey] = true;
+
+    const tokenContract = C.getTokenInstance(tokenAddress);
+    if(!tokenContract) {
+        throw new Error(`unknown token: ${tokenAddress}`);
+    }
+    const allowance = await tokenContract.methods.allowance(ownerAddress, spenderAddress).call();
+    if(new BN(allowance).gt(amountThreshold)) {
+        console.log(`${spenderAddress} already has enough allowance to spend ${tokenSymbol} on behalf of ${ownerAddress}`);
+        return;
+    }
+
+    await waitForPendingTransactions();
+    const nonce = await web3.eth.getTransactionCount(ownerAddress, 'pending');
+    const gasPrice = await C.getGasPrice();
+    console.log(`approving ${spenderAddress} to spend unlimited ${tokenSymbol} on behalf of ${ownerAddress} (nonce ${nonce})`);
+
+    numPendingTransactions++;
+    const txHash = await new Promise((resolve, reject) => {
+        tokenContract.methods.approve(spenderAddress, amount).send({
+            from: ownerAddress,
+            nonce,
+            gas: 200000,
+            gasPrice,
+        }).once(
+            'transactionHash',
+            hash => resolve(hash)
+        ).catch(
+            error => reject(error)
+        );
+    });
+    console.log("tx hash:", txHash);
+    waitForTransaction(txHash).then(txReceipt => {
+        numPendingTransactions--;
+        if(txReceipt.status) {
+            console.log(`Approval transaction successful for ${tokenSymbol}: ${txHash}`);
+        } else {
+            console.error(`Errored approval transaction for ${tokenSymbol}: ${txHash}`);
+        }
+    }).catch(e => {
+        console.error('Error waiting approval transaction', e);
+    });
+}
+
+async function waitForPendingTransactions(max = maxPendingTransactions) {
+    let iteration = 0;
+    while (numPendingTransactions >= max) {
+        if(iteration % 10 === 0) {
+            // avoid spam by only logging every 10 seconds
+            console.log(`Waiting until there are less than ${max} pending transactions (currently ${numPendingTransactions})...`)
+        }
+        iteration++;
+        await Util.wasteTime(1);
+    }
+}
+
+async function waitForTransaction(txHash) {
+    while(true) {
+        let txReceipt = await web3.eth.getTransactionReceipt(txHash);
+        if(txReceipt) {
+            return txReceipt;
+        }
+        await Util.wasteTime(3);
+    }
+}
+
+if(require.main === module) {
+    approve().then(() => {
+        console.log('All wallets approved. Waiting for all transactions');
+        waitForPendingTransactions(1).then(() => {
+            console.log('All wallets approved successfully.')
+        }).catch(e => {
+            console.error('Error waiting for transactions', e);
+        });
+    }).catch(e => {
+        console.error('Error in approval:', e);
+    })
 }


### PR DESCRIPTION
- Send 4 transactions at a time instead of waiting each one individually
- Just approve MAX_UINT256 tokens at once, that way we never need to
  approve again :P
- Check current allowance before approval and don't bother approving if
  allowance > 0.9 * MAX_UINT256
- If same address is used for liquidator and rollover, don't approve
  multiple times
- Make the code a bit more clean