### PR TITLE
84 fix liquidator profit calculation

### DIFF
--- a/controller/liquidator.js
+++ b/controller/liquidator.js
@@ -178,8 +178,8 @@ class Liquidator {
             const liqProfit = Number(C.web3.utils.fromWei(
                 C.web3.utils.toBN(liqEvent.collateralWithdrawAmount).sub(C.web3.utils.toBN(convertedPaidAmount))
             , "Ether")).toFixed(6);
-            console.log(`You made ${liqProfit} ${C.getTokenSymbol(liqEvent.collateralToken)} with this liquidation`);
-            return liqProfit;
+            console.log(`You made ${liqProfit} ${C.getTokenSymbol(liqEvent.collateralToken).toUpperCase()} with this liquidation`);
+            return liqProfit+" "+C.getTokenSymbol(liqEvent.collateralToken).toUpperCase();
         }
         else {
             console.log("Couldn't calculate the profit for the given liquidation");

--- a/tests/test_liquidations.js
+++ b/tests/test_liquidations.js
@@ -68,7 +68,7 @@ describe('Liquidation', async () => {
                 loanToken: '0x69fe5cec81d5ef92600c1a0db1f11986ab3758ab',
                 collateralToken: '0x4d5a316d23ebe168d8f887b4447bf8dbfa4901cc',
                 repayAmount: '714815923163766',
-                collateralWithdrawAmount: '38553133972529282080',
+                collateralWithdrawAmount: '48553133972529282080',
                 collateralToLoanRate: '19468111719705',
                 currentMargin: '9970130076186921178'
             }


### PR DESCRIPTION
Related to #84 

Not as flashy as I thought it would be, but this should fix for once and for all the whole profit calculation for liquidation. The only thing is that I could only test based on DB data, not a fresh liquidation (I'm taking loans right now on testnet, let's see when they expire...)

So the two transactions I used for testing are:

[0x2e3ec10003e575b5764a20c76d019121325c91516569012f23f50815af0d1feb](https://explorer.testnet.rsk.co/tx/0x2e3ec10003e575b5764a20c76d019121325c91516569012f23f50815af0d1feb?__ctab=Token%20Transfers)

[0xb19b774afa1e386e49405a3be906116f709df4ca2814ef5316964c4f24aedbc7](https://explorer.testnet.rsk.co/tx/0xb19b774afa1e386e49405a3be906116f709df4ca2814ef5316964c4f24aedbc7?__ctab=Token%20Transfers)

Looking at the Token Transfers tabs, it is possible to see on the last tab on the bottom the amount and token received for the trade, and above that one the loanToken amount we needed to use for the liquidation. Doing simple math and matching results, I could test that `calculateLiqProfit` is actually working great. 

I also tested using the `test_liquidation.js` file and even compared `getPriceFromAmm` and `getPriceFromPriceFeed` in `calculateLiqProfit`. The latter turns out to be more precise. Here a revealing screenshot testing `calculateLiqProfit`:

![image](https://user-images.githubusercontent.com/40721795/116395362-53041e80-a824-11eb-9823-b33c890c9bdf.png)

Price Feed price seems to be closer to the real price (although still a bit delayed) than AMM price. The Math and logic is good. The difference in a decimal or so with the current BTC price I think is explained by the price feed not updating as often as it could. But the rest is all correct.

I still couldn't test with a fresh liquidation though. Opened hundreds of positions yesterday but it seems to need a bit more time
