### PR TITLE
Rollover tests and fixes

### DIFF
--- a/controller/rollover.js
+++ b/controller/rollover.js
@@ -48,7 +48,8 @@ class Rollover {
             else if(this.positions[p].collateralToken.toLowerCase() === conf.testTokenRBTC.toLowerCase() && amn < 0.00025) continue;
             else if(this.RolloverErrorList[this.positions[p].loanId]>=5) continue;
 
-            if (this.positions[p].endTimestamp < Date.now() / 1000) {
+            const currentTime = Date.now() / 1000;
+            if (this.positions[p].endTimestamp < currentTime) {
                 console.log("Rollover " + this.positions[p].loanId+" pos size: "+amn+" collateralToken: "+C.getTokenSymbol(this.positions[p].collateralToken));
                 const [wallet, wBalance] = await Wallet.getWallet("rollover", 0.001, "rBtc");
                 if (wallet) {
@@ -86,7 +87,14 @@ class Rollover {
                 .catch(async (err) => {
                     console.error("Error in rolling over position "+pos.loanId);
                     console.error(err);
-                    common.telegramBot.sendMessage(`<b><u>R</u></b>\t\t\t\t ⚠️<b>ERROR</b>⚠️\n Error on rollover tx: ${conf.blockExplorer}tx/${err.receipt.transactionHash}
+                    // check if err.receipt exists instead of crashing
+                    let errorDetails;
+                    if(err.receipt) {
+                        errorDetails = `${conf.blockExplorer}tx/${err.receipt.transactionHash}`;
+                    } else {
+                        errorDetails = err.toString().slice(0, 200);
+                    }
+                    common.telegramBot.sendMessage(`<b><u>R</u></b>\t\t\t\t ⚠️<b>ERROR</b>⚠️\n Error on rollover tx: ${errorDetails}
                         \nLoanId: ${U.formatLoanId(pos.loanId)}`, Extra.HTML());
                     p.handleRolloverError(pos.loanId);
                     resolve();

--- a/controller/rollover.js
+++ b/controller/rollover.js
@@ -15,7 +15,7 @@ import dbCtrl from './db';
 
 class Rollover {
     constructor(){
-        this.RolloverErrorList=[];
+        this.rolloverErrorList=[];
         abiDecoder.addABI(abiComplete);
     }
     start(positions) {
@@ -40,21 +40,30 @@ class Rollover {
         console.log("started checking expired positions");
 
         for (let p in this.positions) {
-            const amn = C.web3.utils.fromWei(this.positions[p].collateral.toString(), "Ether");
+            const position = this.positions[p];
+            const amn = C.web3.utils.fromWei(position.collateral.toString(), "Ether");
 
-            if(this.positions[p].collateralToken.toLowerCase() === conf.docToken.toLowerCase() && amn < 5) continue;
-            else if(this.positions[p].collateralToken.toLowerCase() === conf.USDTToken.toLowerCase() && amn < 5) continue;
-            else if(this.positions[p].collateralToken.toLowerCase() === conf.BProToken.toLowerCase()) continue; //Bpro can't be rolled over. Amm messed up
-            else if(this.positions[p].collateralToken.toLowerCase() === conf.testTokenRBTC.toLowerCase() && amn < 0.00025) continue;
-            else if(this.RolloverErrorList[this.positions[p].loanId]>=5) continue;
+            const collateralTokenAddress = position.collateralToken.toLowerCase();
+            if (collateralTokenAddress === conf.docToken.toLowerCase() && amn < 5) {
+                continue;
+            } else if (collateralTokenAddress === conf.USDTToken.toLowerCase() && amn < 5) {
+                continue;
+            } else if (collateralTokenAddress === conf.BProToken.toLowerCase()) {
+                // Bpro can't be rolled over. Amm messed up
+                continue;
+            } else if (collateralTokenAddress === conf.testTokenRBTC.toLowerCase() && amn < 0.00025) {
+                continue;
+            } else if (this.rolloverErrorList[position.loanId] >= 5) {
+                continue;
+            }
 
             const currentTime = Date.now() / 1000;
-            if (this.positions[p].endTimestamp < currentTime) {
-                console.log("Rollover " + this.positions[p].loanId+" pos size: "+amn+" collateralToken: "+C.getTokenSymbol(this.positions[p].collateralToken));
-                const [wallet, wBalance] = await Wallet.getWallet("rollover", 0.001, "rBtc");
+            if (position.endTimestamp < currentTime) {
+                console.log("Rollover " + position.loanId+" pos size: "+amn+" collateralToken: "+C.getTokenSymbol(position.collateralToken));
+                const [wallet] = await Wallet.getWallet("rollover", 0.001, "rBtc");
                 if (wallet) {
                     const nonce = await C.web3.eth.getTransactionCount(wallet.adr, 'pending');
-                    const txHash = await this.rollover(this.positions[p], wallet.adr, nonce);
+                    const txHash = await this.rollover(position, wallet.adr, nonce);
                     if (txHash) await this.addTx(txHash);
                 } else {
                     await this.handleNoWalletError();
@@ -66,51 +75,57 @@ class Rollover {
     /**
      * Tries to rollover a position
      */
-    rollover(pos, wallet, nonce) {
-        const p=this;
-        return new Promise(async (resolve) => {
-            const loanDataBytes = "0x"; //need to be empty
+    async rollover(pos, wallet, nonce) {
+        const loanDataBytes = "0x"; //need to be empty
 
-            const gasPrice = await C.getGasPrice();
+        const gasPrice = await C.getGasPrice();
 
-            C.contractSovryn.methods.rollover(pos.loanId, loanDataBytes)
-                .send({ from: wallet, gas: 2500000, gasPrice: gasPrice, nonce:nonce })
-                .then(async (tx) => {
-                    const msg = `Rollover Transaction successful: ${tx.transactionHash} \n Rolled over position ${U.formatLoanId(pos.loanId)} with ${C.getTokenSymbol(pos.collateralToken)} as collateral token
-                        \n${conf.blockExplorer}tx/${tx.transactionHash}`;
-                    console.log(msg);
-                    common.telegramBot.sendMessage(`<b><u>R</u></b>\t\t\t\t ${conf.network}-${msg}`, Extra.HTML());
+        try {
+            const tx = await C.contractSovryn.methods.rollover(pos.loanId, loanDataBytes).send({
+                from: wallet,
+                gas: 2500000,
+                gasPrice: gasPrice,
+                nonce:nonce
+            });
+            const msg = (
+                `Rollover Transaction successful: ${tx.transactionHash}\n` +
+                `Rolled over position ${U.formatLoanId(pos.loanId)} with ${C.getTokenSymbol(pos.collateralToken)} as collateral token\n` +
+                `${conf.blockExplorer}tx/${tx.transactionHash}`
+            );
+            console.log(msg);
+            common.telegramBot.sendMessage(`<b><u>R</u></b>\t\t\t\t ${conf.network}-${msg}`, Extra.HTML());
 
-                    p.handleRolloverSuccess(pos.loanId);
-                    resolve(tx.transactionHash);
-                })
-                .catch(async (err) => {
-                    console.error("Error in rolling over position "+pos.loanId);
-                    console.error(err);
-                    // check if err.receipt exists instead of crashing
-                    let errorDetails;
-                    if(err.receipt) {
-                        errorDetails = `${conf.blockExplorer}tx/${err.receipt.transactionHash}`;
-                    } else {
-                        errorDetails = err.toString().slice(0, 200);
-                    }
-                    common.telegramBot.sendMessage(`<b><u>R</u></b>\t\t\t\t ⚠️<b>ERROR</b>⚠️\n Error on rollover tx: ${errorDetails}
-                        \nLoanId: ${U.formatLoanId(pos.loanId)}`, Extra.HTML());
-                    p.handleRolloverError(pos.loanId);
-                    resolve();
-                });
-        });
+            this.handleRolloverSuccess(pos.loanId);
+            return tx.transactionHash;
+        } catch(err) {
+            console.error("Error in rolling over position "+pos.loanId);
+            console.error(err);
+
+            // check if err.receipt exists instead of crashing
+            let errorDetails;
+            if(err.receipt) {
+                errorDetails = `${conf.blockExplorer}tx/${err.receipt.transactionHash}`;
+            } else {
+                errorDetails = err.toString().slice(0, 200);
+            }
+
+            common.telegramBot.sendMessage(
+                `<b><u>R</u></b>\t\t\t\t ⚠️<b>ERROR</b>⚠️\n Error on rollover tx: ${errorDetails}\n` +
+                `LoanId: ${U.formatLoanId(pos.loanId)}`,
+                Extra.HTML()
+            );
+            this.handleRolloverError(pos.loanId);
+        }
     }
 
     handleRolloverSuccess(loanId){
-        this.RolloverErrorList[loanId] = null;
+        this.rolloverErrorList[loanId] = null;
     }
 
     handleRolloverError(loanId){
-        if(!this.RolloverErrorList[loanId]) this.RolloverErrorList[loanId]=1;
-        else this.RolloverErrorList[loanId]++;
+        if(!this.rolloverErrorList[loanId]) this.rolloverErrorList[loanId]=1;
+        else this.rolloverErrorList[loanId]++;
     }
-
 
     /**
      * Rollover currently does not emit logs

--- a/integration-tests/initialize_contracts.sh
+++ b/integration-tests/initialize_contracts.sh
@@ -14,14 +14,9 @@ cp -vr oracle-based-amm/solidity/contracts contracts/copied/amm
 
 # RBTCWrapperProxy
 cp -vr oracle-based-amm/rbtcwrapperproxy/ contracts/copied/rbtc
+rm -f contracts/copied/rbtc/WRBTC.sol  # this comes from sovryn-smart-contracts
 
 # Sovryn-smart-contracts
-# NOTE: instead of copying all contracts, we just copy what we need (at least for now)
-mkdir -p contracts/copied/sovryn/feeds/testnet
-mkdir -p contracts/copied/sovryn/interfaces
-cp -vr sovryn-smart-contracts/contracts/feeds/{PriceFeedsConstants,PriceFeeds}.sol contracts/copied/sovryn/feeds/
-cp -vr sovryn-smart-contracts/contracts/feeds/testnet/PriceFeedsLocal.sol contracts/copied/sovryn/feeds/testnet/
-cp -vr sovryn-smart-contracts/contracts/interfaces/{IWrbtcERC20,IWrbtc,IERC20}.sol contracts/copied/sovryn/interfaces
-cp -vr sovryn-smart-contracts/contracts/openzeppelin contracts/copied/sovryn/openzeppelin
+cp -vr sovryn-smart-contracts/contracts contracts/copied/sovryn
 
 echo "All contracts copied."

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "hardhat": "^2.1.2",
+    "sinon": "^10.0.0",
     "truffle": "5.1.36",
     "web3": "^1.2.11"
   }

--- a/integration-tests/test/base/backend.js
+++ b/integration-tests/test/base/backend.js
@@ -21,6 +21,11 @@ export async function initSovrynNodeForTesting({
     rbtcWrapperProxy,
     priceFeeds,
     accounts,
+    sovrynProtocol,
+    loanTokenDoc,
+    loanTokenUsdt,
+    loanTokenBpro,
+    loanTokenWrbtc,
 }) {
     conf.network = 'test';
 
@@ -32,7 +37,6 @@ export async function initSovrynNodeForTesting({
 
     conf.wRbtcWrapper = rbtcWrapperProxy.address.toLowerCase();
     conf.priceFeed  = priceFeeds.address.toLowerCase();
-    //conf.sovrynProtocolAdr  // TODO: handle this, if needed. contract is sovrynProtocol (Protocol.sol)
 
     // sane settings for these
     conf.thresholdArbitrage = 1;
@@ -48,11 +52,12 @@ export async function initSovrynNodeForTesting({
     // Use a different DB too
     conf.db = 'sovryn_node_integration_tests.db';
 
-    // THESE are not yet handled
-    conf.loanTokenSUSD = ZERO_ADDRESS;
-    conf.loanTokenUSDT = ZERO_ADDRESS;
-    conf.loanTokenBPRO = ZERO_ADDRESS;
-    conf.loanTokenRBTC = ZERO_ADDRESS;
+    // Loans
+    conf.sovrynProtocolAdr  = sovrynProtocol.address.toLowerCase();
+    conf.loanTokenSUSD = loanTokenDoc.address.toLowerCase();
+    conf.loanTokenUSDT = loanTokenUsdt.address.toLowerCase();
+    conf.loanTokenBPRO = loanTokenBpro.address.toLowerCase();
+    conf.loanTokenRBTC = loanTokenWrbtc.address.toLowerCase();
 
     // also deal with accounts
     A.liquidator = [

--- a/integration-tests/test/base/ethereum.js
+++ b/integration-tests/test/base/ethereum.js
@@ -1,0 +1,198 @@
+// forked from sovryn-smart-contracts/tests-js/Utils/Ethereum.js
+"use strict";
+
+const BigNumber = require("bignumber.js");
+//const ethers = require("ethers");
+const { ethers } = require("hardhat");
+
+function UInt256Max() {
+    return ethers.constants.MaxUint256;
+}
+
+function address(n) {
+    return `0x${n.toString(16).padStart(40, "0")}`;
+}
+
+function encodeParameters(types, values) {
+    const abi = new ethers.utils.AbiCoder();
+    return abi.encode(types, values);
+}
+
+async function etherBalance(addr) {
+    return new BigNumber(await web3.eth.getBalance(addr));
+}
+
+async function etherGasCost(receipt) {
+    const tx = await web3.eth.getTransaction(receipt.transactionHash);
+    const gasUsed = new BigNumber(receipt.gasUsed);
+    const gasPrice = new BigNumber(tx.gasPrice);
+    return gasUsed.times(gasPrice);
+}
+
+function etherExp(num) {
+    return etherMantissa(num, 1e18);
+}
+
+function etherDouble(num) {
+    return etherMantissa(num, 1e36);
+}
+
+function etherMantissa(num, scale = 1e18) {
+    if (num < 0) return new BigNumber(2).pow(256).plus(num);
+    return new BigNumber(num).times(scale);
+}
+
+function etherUnsigned(num) {
+    return new BigNumber(num);
+}
+
+function mergeInterface(into, from) {
+    const key = (item) => (item.inputs ? `${item.name}/${item.inputs.length}` : item.name);
+    const existing = into.options.jsonInterface.reduce((acc, item) => {
+        acc[key(item)] = true;
+        return acc;
+    }, {});
+    const extended = from.options.jsonInterface.reduce((acc, item) => {
+        if (!(key(item) in existing)) acc.push(item);
+        return acc;
+    }, into.options.jsonInterface.slice());
+    into.options.jsonInterface = into.options.jsonInterface.concat(from.options.jsonInterface);
+    return into;
+}
+
+function getContractDefaults() {
+    return { gas: 20000000, gasPrice: 20000 };
+}
+
+function keccak256(values) {
+    return ethers.utils.keccak256(values);
+}
+
+// not working with hardhat, use hardhat_utils as a workaround
+function unlockedAccounts() {
+    let provider = web3.currentProvider;
+    if (provider._providers) provider = provider._providers.find((p) => p._ganacheProvider)._ganacheProvider;
+    return provider.manager.state.unlocked_accounts;
+}
+
+// not working with hardhat
+function unlockedAccount(a) {
+    return unlockedAccounts()[a.toLowerCase()];
+}
+
+async function mineBlockNumber(blockNumber) {
+    return rpc({ method: "evm_mineBlockNumber", params: [blockNumber] });
+}
+
+async function mineBlock() {
+    return rpc({ method: "evm_mine" });
+}
+
+async function increaseTime(seconds) {
+    await rpc({ method: "evm_increaseTime", params: [seconds] });
+    return rpc({ method: "evm_mine" });
+}
+
+// doesn't work with hardhat
+async function setTime(seconds) {
+    await rpc({ method: "evm_setTime", params: [new Date(seconds * 1000)] });
+}
+
+// doesn't work with hardhat
+async function freezeTime(seconds) {
+    await rpc({ method: "evm_freezeTime", params: [seconds] });
+    return rpc({ method: "evm_mine" });
+}
+
+// adapted for both truffle and hardhat
+async function advanceBlocks(blocks) {
+    //let res = parseInt(await rpc({ method: "eth_blockNumber" }), 16);
+    //console.log(`await rpc({ method: "eth_blockNumber" }): ${res}`);
+    let currentBlockNumber = await blockNumber();
+    //console.log(`Ethereum::currentBlockNumber: ${currentBlockNumber}`);
+    //let { result: num } = await rpc({ method: "eth_blockNumber" });
+    //await rpc({ method: "evm_mineBlockNumber", params: [blocks + parseInt(num)] });
+    //await rpc({ method: "evm_mineBlockNumber", params: [blocks + num] });
+    for (let i = currentBlockNumber; i < blocks; i++) {
+        await mineBlock();
+    }
+}
+
+async function setNextBlockTimestamp(timestamp) {
+    await rpc({ method: "evm_setNextBlockTimestamp", params: [timestamp] });
+}
+
+async function blockNumber() {
+    let { result: num } = await rpc({ method: "eth_blockNumber" });
+    if (num === undefined) num = await rpc({ method: "eth_blockNumber" });
+    //let { result: num } = await rpc({ method: "eth_blockNumber" });
+    return parseInt(num);
+    //return num;
+}
+
+async function lastBlock() {
+    return await rpc({ method: "eth_getBlockByNumber", params: ["latest", true] });
+}
+
+// doesn't work with hardhat
+async function minerStart() {
+    return rpc({ method: "miner_start" });
+}
+
+// doesn't work with hardhat
+async function minerStop() {
+    return rpc({ method: "miner_stop" });
+}
+
+// adapted to work in both truffle and hardhat
+async function rpc(request) {
+    try {
+        return await network.provider.request(request);
+    } catch (e) {
+        if (typeof network != "undefined") console.error(e);
+        //console.log("Ethereum.js rpc:: network is undefined. Trying web3.currentProvider.send...");
+        return new Promise((okay, fail) => web3.currentProvider.send(request, (err, res) => (err ? fail(err) : okay(res))));
+    }
+}
+
+async function both(contract, method, args = [], opts = {}) {
+    const reply = await call(contract, method, args, opts);
+    const receipt = await send(contract, method, args, opts);
+    return { reply, receipt };
+}
+
+async function sendFallback(contract, opts = {}) {
+    const receipt = await web3.eth.sendTransaction({ to: contract._address, ...Object.assign(getContractDefaults(), opts) });
+    return Object.assign(receipt, { events: receipt.logs });
+}
+
+module.exports = {
+    address,
+    encodeParameters,
+    etherBalance,
+    etherGasCost,
+    etherExp,
+    etherDouble,
+    etherMantissa,
+    etherUnsigned,
+    mergeInterface,
+    keccak256,
+    unlockedAccounts,
+    unlockedAccount,
+
+    advanceBlocks,
+    blockNumber,
+    lastBlock,
+    freezeTime,
+    increaseTime,
+    mineBlock,
+    mineBlockNumber,
+    minerStart,
+    minerStop,
+    rpc,
+    setTime,
+    setNextBlockTimestamp,
+    both,
+    sendFallback,
+    UInt256Max,
+};

--- a/integration-tests/test/base/loans.js
+++ b/integration-tests/test/base/loans.js
@@ -108,7 +108,14 @@ export const deployLoanTokenWRBTC = async (loanTokenLogicWrbtc, owner, sovryn, W
     return loanTokenWRBTC;
 };
 
-export const initLoanPool = async ({ sovrynProtocol, owner, wrbtcToken, token, loanToken, loanTokenWrbtc }) => {
+export const initLoanPool = async ({
+    sovrynProtocol,
+    owner,
+    wrbtcToken,
+    token,
+    loanToken,
+    loanTokenWrbtc
+}) => {
     // old loan_pool_setup
     let params = [];
     let config = [

--- a/integration-tests/test/base/loans.js
+++ b/integration-tests/test/base/loans.js
@@ -1,0 +1,304 @@
+// This is forked sovryn-smart-contracts/tests-js/Utils/initializer.js
+const { BN } = require("@openzeppelin/test-helpers");
+const constants = require("@openzeppelin/test-helpers/src/constants");
+const { expect } = require("chai");
+
+const ProtocolSettings = artifacts.require("ProtocolSettings");
+const SovrynProtocol = artifacts.require("sovrynProtocol");
+const ISovryn = artifacts.require("ISovryn");
+
+const LoanSettings = artifacts.require("LoanSettings");
+const LoanMaintenance = artifacts.require("LoanMaintenance");
+const LoanOpenings = artifacts.require("LoanOpenings");
+const LoanClosings = artifacts.require("LoanClosings");
+
+const SwapsExternal = artifacts.require("SwapsExternal");
+
+const LoanToken = artifacts.require("LoanToken");
+const LoanTokenLogicStandard = artifacts.require("LoanTokenLogicTest");
+const LoanTokenLogicWrbtc = artifacts.require("LoanTokenLogicWrbtc");
+
+const SwapsImplSovrynSwap = artifacts.require("SwapsImplSovrynSwap");
+
+const wei = web3.utils.toWei;
+const oneEth = new BN(wei("1", "ether"));
+const hunEth = new BN(wei("100", "ether"));
+
+const CONSTANTS = {
+    ZERO_ADDRESS: "0x0000000000000000000000000000000000000000",
+    ONE_ADDRESS: "0x0000000000000000000000000000000000000001",
+    MAX_UINT: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+};
+
+export const deploySovrynProtocol = async ({
+    wrbtcToken,
+    usdtToken,
+    docToken,
+    bproToken,
+    contractRegistry,
+    priceFeeds
+}) => {
+    const sovrynproxy = await SovrynProtocol.new();
+    const sovryn = await ISovryn.at(sovrynproxy.address);
+
+    await sovryn.replaceContract((await ProtocolSettings.new()).address);
+    await sovryn.replaceContract((await LoanSettings.new()).address);
+    await sovryn.replaceContract((await LoanMaintenance.new()).address);
+    await sovryn.replaceContract((await SwapsExternal.new()).address);
+
+    //const sovrynSwapSimulator = await TestSovrynSwap.new(priceFeeds.address);
+    //await sovryn.setSovrynSwapContractRegistryAddress(sovrynSwapSimulator.address);
+    await sovryn.setSovrynSwapContractRegistryAddress(contractRegistry.address);
+
+    await sovryn.setSupportedTokens(
+        [usdtToken.address, docToken.address, bproToken.address, wrbtcToken.address],
+        [true, true, true, true]
+    );
+
+    await sovryn.setWrbtcToken(wrbtcToken.address);
+
+    // loanOpening
+    const swaps = await SwapsImplSovrynSwap.new();
+    await sovryn.replaceContract((await LoanOpenings.new()).address);
+    await sovryn.setPriceFeedContract(priceFeeds.address);
+    await sovryn.setSwapsImplContract(swaps.address);
+
+    // loanClosing
+    await sovryn.replaceContract((await LoanClosings.new()).address);
+    return sovryn;
+};
+
+
+// Loan Token
+
+export const deployLoanTokenLogic = async () => {
+    const loanTokenLogicStandard = await LoanTokenLogicStandard.new();
+    return loanTokenLogicStandard;
+};
+export const deployLoanTokenLogicWrbtc = async () => {
+    const loanTokenLogicWrbtc = await LoanTokenLogicWrbtc.new();
+    return loanTokenLogicWrbtc;
+};
+
+export const deployLoanTokenSettings = async () => {
+    const loanSettings = await LoanSettings.new();
+    return loanSettings;
+};
+
+export const deployLoanToken = async (loanTokenLogicStandard, owner, sovryn, WRBTC, token) => {
+    let loanToken = await LoanToken.new(owner, loanTokenLogicStandard.address, sovryn.address, WRBTC.address);
+    const symbol = await token.symbol();
+    await loanToken.initialize(token.address, `i${symbol}`, `i${symbol}`); //iToken
+    loanToken = await LoanTokenLogicStandard.at(loanToken.address);
+    // assert loanToken.tokenPrice() == loanToken.initialPrice()
+    // const initial_total_supply = await loanToken.totalSupply();
+    // loan token total supply should be zero
+    // assert initial_total_supply == loanToken.totalSupply()
+    return loanToken;
+};
+
+export const deployLoanTokenWRBTC = async (loanTokenLogicWrbtc, owner, sovryn, WRBTC) => {
+    let loanTokenWRBTC = await LoanToken.new(owner, loanTokenLogicWrbtc.address, sovryn.address, WRBTC.address);
+    await loanTokenWRBTC.initialize(WRBTC.address, "iWRBTC", "iWRBTC"); //iToken
+    loanTokenWRBTC = await LoanTokenLogicWrbtc.at(loanTokenWRBTC.address);
+    // assert loanToken.tokenPrice() == loanToken.initialPrice()
+    // const initial_total_supply = await loanToken.totalSupply();
+    // loan token total supply should be zero
+    // assert initial_total_supply == loanToken.totalSupply()
+    return loanTokenWRBTC;
+};
+
+export const initLoanPool = async ({ sovrynProtocol, owner, wrbtcToken, token, loanToken, loanTokenWrbtc }) => {
+    // old loan_pool_setup
+    let params = [];
+    let config = [
+        "0x0000000000000000000000000000000000000000000000000000000000000000", // bytes32 id; // id of loan params object
+        false, // bool active; // if false, this object has been disabled by the owner and can't be used for future loans
+        owner, // address owner; // owner of this object
+        CONSTANTS.ZERO_ADDRESS, // address loanToken; // the token being loaned
+        wrbtcToken.address, // address collateralToken; // the required collateral token
+        wei("20", "ether"), // uint256 minInitialMargin; // the minimum allowed initial margin
+        wei("15", "ether"), // uint256 maintenanceMargin; // an unhealthy loan when current margin is at or below this value
+        0, // uint256 maxLoanTerm; // the maximum term for new loans (0 means there's no max term)
+    ];
+    params.push(config);
+    //const copy1 = [...config];
+    //copy1[4] = WRBTC.address;
+    //params.push(copy1);
+
+    await loanToken.setupLoanParams(params, false);
+    await loanToken.setupLoanParams(params, true);
+
+    params = [];
+    const copy2 = [...config];
+    copy2[4] = token.address;
+    params.push(copy2);
+
+    await loanTokenWrbtc.setupLoanParams(params, false);
+    await loanTokenWrbtc.setupLoanParams(params, true);
+
+    await sovrynProtocol.setLoanPool([loanToken.address, loanTokenWrbtc.address], [token.address, wrbtcToken.address]);
+};
+
+export const setDemandCurve = async (loanToken, opts = {}) => {
+    const {
+        baseRate = wei("1", "ether"),
+        rateMultiplier = wei("20.25", "ether"),
+        targetLevel = wei("80", "ether"),
+        kinkLevel = wei("90", "ether"),
+        maxScaleRate = wei("100", "ether"),
+    } = opts;
+
+    const localLoanToken = await LoanTokenLogicStandard.at(loanToken.address);
+    await localLoanToken.setDemandCurve(baseRate, rateMultiplier, baseRate, rateMultiplier, targetLevel, kinkLevel, maxScaleRate);
+    // borrow_interest_rate = loanToken.borrowInterestRate();
+    // print("borrowInterestRate: ", borrow_interest_rate);
+    // assert(borrow_interest_rate > baseRate);
+};
+
+export const lend_to_pool = async (loanToken, SUSD, lender) => {
+    const lend_amount = new BN(10).pow(new BN(30)).toString();
+    await SUSD.mint(lender, lend_amount);
+    await SUSD.approve(loanToken.address, lend_amount);
+    await loanToken.mint(lender, lend_amount);
+    return [lender, lend_amount];
+};
+
+export const lend_to_pool_iBTC = async (loanTokenWRBTC, lender) => {
+    const lend_amount = new BN(10).pow(new BN(21)).toString();
+    await loanTokenWRBTC.mintWithBTC(lender, { from: lender, value: lend_amount });
+    return [lender, lend_amount];
+};
+
+export const open_margin_trade_position = async (
+    loanToken,
+    RBTC,
+    WRBTC,
+    SUSD,
+    trader,
+    collateral = "RBTC",
+    loan_token_sent = hunEth.toString(),
+    leverage_amount = new BN(2).mul(oneEth).toString()
+) => {
+    await SUSD.mint(trader, loan_token_sent);
+    await SUSD.approve(loanToken.address, loan_token_sent, { from: trader });
+
+    let collateralToken;
+    if (collateral == "RBTC") collateralToken = RBTC.address;
+    else collateralToken = WRBTC.address;
+
+    const { receipt } = await loanToken.marginTrade(
+        "0x0", // loanId  (0 for new loans)
+        leverage_amount, // leverageAmount
+        loan_token_sent, // loanTokenSent
+        0, // no collateral token sent
+        collateralToken, // collateralTokenAddress
+        trader, // trader,
+        [], // loanDataBytes (only required with ether)
+        { from: trader }
+    );
+    const decode = decodeLogs(receipt.rawLogs, LoanOpenings, "Trade");
+    return [decode[0].args["loanId"], trader, loan_token_sent, leverage_amount];
+};
+
+export const open_margin_trade_position_iBTC = async (
+    loanTokenWRBTC,
+    SUSD,
+    trader,
+    loan_token_sent = oneEth.toString(),
+    leverage_amount = new BN(2).mul(oneEth).toString()
+) => {
+    const { receipt } = await loanTokenWRBTC.marginTrade(
+        "0x0", // loanId  (0 for new loans)
+        leverage_amount, // leverageAmount
+        loan_token_sent, // loanTokenSent
+        0, // no collateral token sent
+        SUSD.address, // collateralTokenAddress
+        trader, // trader,
+        [], // loanDataBytes (only required with ether)
+        { from: trader, value: loan_token_sent }
+    );
+
+    const decode = decodeLogs(receipt.rawLogs, LoanOpenings, "Trade");
+    return [decode[0].args["loanId"], trader, loan_token_sent, leverage_amount];
+};
+
+export const borrow_indefinite_loan = async (
+    loanToken,
+    sovryn,
+    SUSD,
+    RBTC,
+    accounts,
+    withdraw_amount = new BN(10).mul(oneEth).toString(),
+    margin = new BN(50).mul(oneEth).toString(),
+    duration_in_seconds = 60 * 60 * 24 * 10
+) => {
+    const borrower = accounts[2];
+    const receiver = accounts[1];
+    const collateral_token_sent = await sovryn.getRequiredCollateral(SUSD.address, RBTC.address, withdraw_amount, margin, true);
+    // approve the transfer of the collateral
+    await RBTC.mint(borrower, collateral_token_sent);
+    await RBTC.approve(loanToken.address, collateral_token_sent, { from: borrower });
+    // borrow some funds
+    const tx = await loanToken.borrow(
+        constants.ZERO_BYTES32, // bytes32 loanId
+        withdraw_amount, // uint256 withdrawAmount
+        duration_in_seconds, // uint256 initialLoanDuration
+        collateral_token_sent, // uint256 collateralTokenSent
+        RBTC.address, // address collateralTokenAddress
+        borrower, // address borrower
+        receiver, // address receiver
+        "0x", // bytes memory loanDataBytes
+        { from: borrower }
+    );
+    const decode = decodeLogs(tx.receipt.rawLogs, LoanOpenings, "Borrow");
+    const loan_id = decode[0].args["loanId"];
+    return [loan_id, borrower, receiver, withdraw_amount, duration_in_seconds, margin, decode[0].args];
+};
+
+export function decodeLogs(logs, emitter, eventName) {
+    let abi;
+    let address;
+    abi = emitter.abi;
+    try {
+        address = emitter.address;
+    } catch (e) {
+        address = null;
+    }
+
+    let eventABI = abi.filter((x) => x.type === "event" && x.name === eventName);
+    if (eventABI.length === 0) {
+        throw new Error(`No ABI entry for event '${eventName}'`);
+    } else if (eventABI.length > 1) {
+        throw new Error(`Multiple ABI entries for event '${eventName}', only uniquely named events are supported`);
+    }
+
+    eventABI = eventABI[0];
+
+    // The first topic will equal the hash of the event signature
+    const eventSignature = `${eventName}(${eventABI.inputs.map((input) => input.type).join(",")})`;
+    const eventTopic = web3.utils.sha3(eventSignature);
+
+    // Only decode events of type 'EventName'
+    return logs
+        .filter((log) => log.topics.length > 0 && log.topics[0] === eventTopic && (!address || log.address === address))
+        .map((log) => web3.eth.abi.decodeLog(eventABI.inputs, log.data, log.topics.slice(1)))
+        .map((decoded) => ({ event: eventName, args: decoded }));
+}
+
+export const verify_sov_reward_payment = async (logs, FeesEvents, SOV, borrower, loan_id, sov_initial_balance, expected_events_number) => {
+    const earn_reward_events = decodeLogs(logs, FeesEvents, "EarnReward");
+    const len = earn_reward_events.length;
+    expect(len).to.equal(expected_events_number);
+
+    let reward = new BN(0);
+    for (let i = 0; i < len; i++) {
+        const args = earn_reward_events[i].args;
+        expect(args["receiver"]).to.equal(borrower);
+        expect(args["token"]).to.equal(SOV.address);
+        expect(args["loanId"]).to.equal(loan_id);
+        reward = reward.add(new BN(args["amount"]));
+    }
+
+    expect(await SOV.balanceOf(borrower)).to.be.a.bignumber.equal(sov_initial_balance.add(reward));
+};

--- a/integration-tests/test/base/utils.js
+++ b/integration-tests/test/base/utils.js
@@ -1,0 +1,31 @@
+import C from '../../../controller/contract';
+const { BN } = require("@openzeppelin/test-helpers");
+import abiTestToken from '../../../config/abiTestToken';
+
+export async function printAccountDetails({
+    accounts = [],
+    tokenAddresses = [],
+}) {
+    console.log('ACCOUNT DETAILS');
+    for (let tokenAddress of tokenAddresses) {
+        let tokenContract = C.getTokenInstance(tokenAddress)
+        if(!tokenContract) {
+            console.log(` NOTE: Contract not found for token ${tokenAddress} from controller`);
+            tokenContract = new C.web3.eth.Contract(abiTestToken, tokenAddress);
+            try {
+                const symbol = await tokenContract.methods.symbol().call();
+                console.log(`  Token: ${symbol} (${tokenAddress})`);
+            } catch (e) {
+                // swallow
+            }
+            return;
+        }
+
+        const symbol = await tokenContract.methods.symbol().call();
+        console.log(`  Token: ${symbol} (${tokenAddress})`);
+        for(let account of accounts) {
+            const balance = new BN(await tokenContract.methods.balanceOf(account).call());
+            console.log(`    ${symbol}.balanceOf(${account}) = ${balance.toString()}`);
+        }
+    }
+}

--- a/integration-tests/test/test_rollover.js
+++ b/integration-tests/test/test_rollover.js
@@ -87,7 +87,6 @@ describe("Rollover controller", () => {
     const setupRolloverTest = async (token, loanToken) => {
         const sovryn = sovrynContracts.sovrynProtocol;
         const wrbtcToken = sovrynContracts.wrbtcToken;
-        const accounts = sovrynContracts.accounts;
 
         await setDemandCurve(loanToken);
         await token.approve(loanToken.address, new BN(10).pow(new BN(40)));
@@ -198,8 +197,6 @@ describe("Rollover controller", () => {
         const rows = await getRolloversFromDB();
         expect(rows.length).to.equal(1);
         const rolloverRow = rows[0];
-
-        console.log(sovrynContracts.accounts);
 
         // TODO: what address should this be then?
         //expect(rolloverRow.rolloverAdr.toLowerCase()).to.equal(rolloverAddress.toLowerCase());

--- a/integration-tests/test/test_rollover.js
+++ b/integration-tests/test/test_rollover.js
@@ -1,33 +1,45 @@
 import { expect } from 'chai';
-import { BN, ether, constants } from '@openzeppelin/test-helpers';
-const { MAX_UINT256 } = constants;
+import { BN } from '@openzeppelin/test-helpers';
 
 import A from '../../secrets/accounts';
 import Rollover from '../../controller/rollover';
 import PositionScanner from '../../controller/scanner';
+import DB from '../../controller/db';
 
-const FeesEvents = artifacts.require("FeesEvents");
 const LoanOpeningsEvents = artifacts.require("LoanOpeningsEvents");
-const SwapsEvents = artifacts.require("SwapsEvents");
 import {initSovrynNodeForTesting} from "./base/backend";
 import {ConverterHelper, initSovrynContracts} from "./base/contracts";
 import {initLoanPool, decodeLogs, setDemandCurve} from "./base/loans";
-import { increaseTime, blockNumber } from './base/ethereum';
-
+import {increaseTime} from './base/ethereum';
 
 const wei = web3.utils.toWei;
 const oneEth = new BN(wei("1", "ether"));
 const hunEth = new BN(wei("100", "ether"));
 
-
 describe("Rollover controller", () => {
-    let liquidatorAddress;
+    let rolloverAddress;
+    let lenderAddress;
+    let borrowerAddress;
     let contractOwnerAddress;
     let positions;
     let liquidations;
 
     let sovrynContracts;
     let converters;
+    let liquidityPool;
+
+    let currentTime = 1337000;
+    let savedNow = Date.now;
+
+    before(() => {
+        // mock date function, always return currentTime
+        global.Date.now = () => currentTime;
+    })
+
+    after(() => {
+        // restore the mocked now function
+        global.Date.now = savedNow;
+    })
 
     beforeEach(async () => {
         liquidations = {};
@@ -37,7 +49,9 @@ describe("Rollover controller", () => {
         converters = new ConverterHelper(sovrynContracts);
 
         contractOwnerAddress = sovrynContracts.accountOwner;
-        liquidatorAddress = A.liquidator[0].adr;
+        rolloverAddress = A.rollover[0].adr;
+        lenderAddress = sovrynContracts.accounts[0];
+        borrowerAddress = sovrynContracts.accounts[1];
         PositionScanner.liquidations = liquidations;
         PositionScanner.positions = positions;
         PositionScanner.positionsTmp = {};
@@ -52,7 +66,7 @@ describe("Rollover controller", () => {
             loanTokenWrbtc: sovrynContracts.loanTokenWrbtc,
         });
         // the converter needs to be deployed, otherwise it won't work
-        await converters.initConverter({
+        liquidityPool = await converters.initConverter({
             primaryReserveToken: sovrynContracts.wrbtcToken,
             secondaryReserveToken: sovrynContracts.docToken,
             initialPrimaryReserveLiquidity:       new BN('159658299529181487177'),
@@ -65,6 +79,9 @@ describe("Rollover controller", () => {
             secondaryPriceOracleAnswer:   new BN('1000000000000000000'),
         })
 
+        //await sovrynContracts.wrbtcToken.transfer(rolloverAddress, ether('100'));
+        //await sovrynContracts.docToken.transfer(rolloverAddress, ether('100'));
+        currentTime = 1337000;
     });
 
     const setupRolloverTest = async (token, loanToken) => {
@@ -74,12 +91,10 @@ describe("Rollover controller", () => {
 
         await setDemandCurve(loanToken);
         await token.approve(loanToken.address, new BN(10).pow(new BN(40)));
-        const lender = accounts[0];
-        const borrower = accounts[1];
-        await loanToken.mint(lender, new BN(10).pow(new BN(30)));
+        await loanToken.mint(lenderAddress, new BN(10).pow(new BN(30)));
         const loanTokenSent = hunEth;
-        await token.mint(borrower, loanTokenSent);
-        await token.approve(loanToken.address, loanTokenSent, { from: borrower });
+        await token.mint(borrowerAddress, loanTokenSent);
+        await token.approve(loanToken.address, loanTokenSent, { from: borrowerAddress });
 
         const { receipt } = await loanToken.marginTrade(
             "0x0", // loanId  (0 for new loans)
@@ -87,30 +102,112 @@ describe("Rollover controller", () => {
             loanTokenSent, // loanTokenSent
             0, // no collateral token sent
             wrbtcToken.address, // collateralTokenAddress
-            borrower, // trader,
+            borrowerAddress, // trader,
             "0x", // loanDataBytes (only required with ether)
-            { from: borrower }
+            { from: borrowerAddress }
         );
 
         const decode = decodeLogs(receipt.rawLogs, LoanOpeningsEvents, "Trade");
-        const loan_id = decode[0].args["loanId"];
-        const loan = await sovryn.getLoan(loan_id);
-        const num = await blockNumber();
-        let currentBlock = await web3.eth.getBlock(num);
-        const block_timestamp = currentBlock.timestamp;
-        const time_until_loan_end = loan["endTimestamp"] - block_timestamp;
-        await increaseTime(time_until_loan_end);
-        return [borrower, loan, loan_id, parseInt(loan["endTimestamp"])];
+        const loanId = decode[0].args["loanId"];
+        const loan = await sovryn.getLoan(loanId);
+
+        // subtract a random amount from the liquidity pool so that min amount is ok when doing collateral
+        // conversion.
+        // argh.
+        await liquidityPool.subtractFromReserveBalance(
+            sovrynContracts.wrbtcToken.address,
+            new BN('59658299529181487177')
+        );
+
+        return {
+            loan,
+            loanId,
+            loanEndTimestamp: parseInt(loan.endTimestamp),
+        };
     };
 
+    async function scanPositions(from = 0, to) {
+        // because the PositionScanner logic is inside an infinite loop,
+        // do this manually.
+        // should rather refactor PositionScanner to be more testable
+        if(to === undefined) {
+            to = await web3.eth.getBlockNumber();
+        }
+        const activePositions = await PositionScanner.loadActivePositions(from, to);
+        PositionScanner.addPosition(activePositions);  // this mutates positionsTmp, not positions
+        // we have to manually add them to the positions
+        for(let [k, v] of Object.entries(PositionScanner.positionsTmp)) {
+            positions[k] = v;
+        }
+        PositionScanner.positionsTmp = {};
+    }
 
-    it("should work", async () => {
-        await setupRolloverTest(sovrynContracts.docToken, sovrynContracts.loanTokenDoc);
-        const currentBlock = await web3.eth.getBlockNumber();
-        const positions = await PositionScanner.loadActivePositions(0, currentBlock);
-        console.log('positions:', positions);
-        PositionScanner.addPosition(positions);
-        const result = await Rollover.handleRolloverRound();
-        expect(result).to.equal(undefined);
+    async function advanceTime({
+        blockchainTimestamp = 0,
+        nodeTimestamp = 0,
+    }) {
+        if(blockchainTimestamp) {
+            const currentBlock = await web3.eth.getBlock('latest');
+            const difference = blockchainTimestamp - currentBlock.timestamp;
+            if (difference < 0) {
+                console.warn('would advance backwards which makes no sense');
+            } else if (difference > 0) {
+                await increaseTime(difference);
+            }
+        }
+
+        if(nodeTimestamp) {
+            currentTime = nodeTimestamp * 1000;
+        }
+    }
+
+    async function getRolloversFromDB() {
+        return await DB.rollRepo.all("SELECT * FROM rollover");
+    }
+
+    it("should not rollover when a loan has not expired", async () => {
+        const {
+            loanEndTimestamp,
+            loanId,
+        } = await setupRolloverTest(sovrynContracts.docToken, sovrynContracts.loanTokenDoc);
+
+        await advanceTime({
+            blockchainTimestamp: loanEndTimestamp - 1,
+            nodeTimestamp: loanEndTimestamp - 1,
+        });
+        await scanPositions();
+
+        await Rollover.handleRolloverRound();
+        const rows = await getRolloversFromDB();
+        expect(rows.length).to.equal(0);
+    });
+
+    it("should rollover when a loan has expired", async () => {
+        const {
+            loanEndTimestamp,
+            loanId,
+        } = await setupRolloverTest(sovrynContracts.docToken, sovrynContracts.loanTokenDoc);
+
+        await advanceTime({
+            blockchainTimestamp: loanEndTimestamp + 1,
+            nodeTimestamp: loanEndTimestamp + 1,
+        });
+        await scanPositions();
+
+        await Rollover.handleRolloverRound();
+        const rows = await getRolloversFromDB();
+        expect(rows.length).to.equal(1);
+        const rolloverRow = rows[0];
+
+        console.log(sovrynContracts.accounts);
+
+        // TODO: what address should this be then?
+        //expect(rolloverRow.rolloverAdr.toLowerCase()).to.equal(rolloverAddress.toLowerCase());
+
+        expect(rolloverRow.rolledoverAdr.toLowerCase()).to.equal(borrowerAddress.toLowerCase());
+        expect(rolloverRow.loanId).to.equal(loanId);
+        expect(rolloverRow.amount).to.equal('0.000045');
+        expect(rolloverRow.pos).to.equal('long');
+        // could maybe test something in the blockchain too...
     });
 });

--- a/integration-tests/test/test_rollover.js
+++ b/integration-tests/test/test_rollover.js
@@ -1,0 +1,116 @@
+import { expect } from 'chai';
+import { BN, ether, constants } from '@openzeppelin/test-helpers';
+const { MAX_UINT256 } = constants;
+
+import A from '../../secrets/accounts';
+import Rollover from '../../controller/rollover';
+import PositionScanner from '../../controller/scanner';
+
+const FeesEvents = artifacts.require("FeesEvents");
+const LoanOpeningsEvents = artifacts.require("LoanOpeningsEvents");
+const SwapsEvents = artifacts.require("SwapsEvents");
+import {initSovrynNodeForTesting} from "./base/backend";
+import {ConverterHelper, initSovrynContracts} from "./base/contracts";
+import {initLoanPool, decodeLogs, setDemandCurve} from "./base/loans";
+import { increaseTime, blockNumber } from './base/ethereum';
+
+
+const wei = web3.utils.toWei;
+const oneEth = new BN(wei("1", "ether"));
+const hunEth = new BN(wei("100", "ether"));
+
+
+describe("Rollover controller", () => {
+    let liquidatorAddress;
+    let contractOwnerAddress;
+    let positions;
+    let liquidations;
+
+    let sovrynContracts;
+    let converters;
+
+    beforeEach(async () => {
+        liquidations = {};
+        positions = {};
+        sovrynContracts = await initSovrynContracts();
+        await initSovrynNodeForTesting(sovrynContracts);
+        converters = new ConverterHelper(sovrynContracts);
+
+        contractOwnerAddress = sovrynContracts.accountOwner;
+        liquidatorAddress = A.liquidator[0].adr;
+        PositionScanner.liquidations = liquidations;
+        PositionScanner.positions = positions;
+        PositionScanner.positionsTmp = {};
+        Rollover.positions = positions;
+
+        await initLoanPool({
+            sovrynProtocol: sovrynContracts.sovrynProtocol,
+            owner: sovrynContracts.accountOwner,
+            wrbtcToken: sovrynContracts.wrbtcToken,
+            token: sovrynContracts.docToken,
+            loanToken: sovrynContracts.loanTokenDoc,
+            loanTokenWrbtc: sovrynContracts.loanTokenWrbtc,
+        });
+        // the converter needs to be deployed, otherwise it won't work
+        await converters.initConverter({
+            primaryReserveToken: sovrynContracts.wrbtcToken,
+            secondaryReserveToken: sovrynContracts.docToken,
+            initialPrimaryReserveLiquidity:       new BN('159658299529181487177'),
+            initialSecondaryReserveLiquidity: new BN('2344204953216918397465575'),
+            finalPrimaryReserveBalance:           new BN('184968372923849153200'),
+            finalSecondaryReserveBalance:      new BN('769563135046785056451752'),
+            finalPrimaryReserveWeight:   812160,
+            finalSecondaryReserveWeight: 187840,
+            primaryPriceOracleAnswer: new BN('63500099999999998544808'),
+            secondaryPriceOracleAnswer:   new BN('1000000000000000000'),
+        })
+
+    });
+
+    const setupRolloverTest = async (token, loanToken) => {
+        const sovryn = sovrynContracts.sovrynProtocol;
+        const wrbtcToken = sovrynContracts.wrbtcToken;
+        const accounts = sovrynContracts.accounts;
+
+        await setDemandCurve(loanToken);
+        await token.approve(loanToken.address, new BN(10).pow(new BN(40)));
+        const lender = accounts[0];
+        const borrower = accounts[1];
+        await loanToken.mint(lender, new BN(10).pow(new BN(30)));
+        const loanTokenSent = hunEth;
+        await token.mint(borrower, loanTokenSent);
+        await token.approve(loanToken.address, loanTokenSent, { from: borrower });
+
+        const { receipt } = await loanToken.marginTrade(
+            "0x0", // loanId  (0 for new loans)
+            new BN(2).mul(oneEth), // leverageAmount
+            loanTokenSent, // loanTokenSent
+            0, // no collateral token sent
+            wrbtcToken.address, // collateralTokenAddress
+            borrower, // trader,
+            "0x", // loanDataBytes (only required with ether)
+            { from: borrower }
+        );
+
+        const decode = decodeLogs(receipt.rawLogs, LoanOpeningsEvents, "Trade");
+        const loan_id = decode[0].args["loanId"];
+        const loan = await sovryn.getLoan(loan_id);
+        const num = await blockNumber();
+        let currentBlock = await web3.eth.getBlock(num);
+        const block_timestamp = currentBlock.timestamp;
+        const time_until_loan_end = loan["endTimestamp"] - block_timestamp;
+        await increaseTime(time_until_loan_end);
+        return [borrower, loan, loan_id, parseInt(loan["endTimestamp"])];
+    };
+
+
+    it("should work", async () => {
+        await setupRolloverTest(sovrynContracts.docToken, sovrynContracts.loanTokenDoc);
+        const currentBlock = await web3.eth.getBlockNumber();
+        const positions = await PositionScanner.loadActivePositions(0, currentBlock);
+        console.log('positions:', positions);
+        PositionScanner.addPosition(positions);
+        const result = await Rollover.handleRolloverRound();
+        expect(result).to.equal(undefined);
+    });
+});


### PR DESCRIPTION
Don't send rollovers that have already been sent (Closes #83)

The request was to prevent failed rollovers from being sent again. There was already logic in place for this, where it would try one rollover at most 4 times if it fails. However, I changed it so that it keeps track of all sent rollovers and doesn't try sending them again, no matter if they fail or succeed. Reasoning being: if we send an already sent rollover again, it will fail, and I think it's possible we do that if we run `Rollover` twice before `PositionScanner` can pick up the closed rollover.

Also:
- Working Hardhat integration tests for rollover (also a basis for liquidation tests)
- Refactoring/reformatting rollover code
