### PR TITLE
Fix unknown log in rollover

### DIFF
--- a/controller/wallet.js
+++ b/controller/wallet.js
@@ -31,7 +31,7 @@ class Wallet {
      * Careful: Consider decimals for tokens. Rbtc and Doc have 18
      */
     async getWallet(type, reqTokenBalance, token) {
-        console.log("Checking wallet of type " + type + ", required token Balance: " + reqTokenBalance + ", for token: " + token === "rBtc" ? "rBtc" : C.getTokenSymbol(token));
+        console.log("Checking wallet of type " + type + ", required token Balance: " + reqTokenBalance + ", for token: " + (token == "rBtc" ? "rBtc" : C.getTokenSymbol(token)));
         for (let wallet of A[type]) {
             if (this.queue[type][wallet.adr].length >= 4) continue;
 


### PR DESCRIPTION
Fixes this

`(unknown)` popping up in the logs (I have seen it also in arbitrage, not only rollover)

![image](https://user-images.githubusercontent.com/40721795/116694759-f5a4d480-a9bf-11eb-8cbd-c2fc724d87fb.png)
