### PR TITLE
Liquidation and rollover fixes and improvements

### DIFF
--- a/controller/common.js
+++ b/controller/common.js
@@ -11,7 +11,7 @@ class TelegramBot {
     async sendMessage(msg, extra) {
         if (this.bot) {
             try {
-                this.bot.sendMessage(conf.sovrynInternalTelegramId, msg, extra);
+                await this.bot.sendMessage(conf.sovrynInternalTelegramId, msg, extra);
             } catch(err) {
                 console.log(err)
             }

--- a/controller/liquidator.js
+++ b/controller/liquidator.js
@@ -46,8 +46,12 @@ class Liquidator {
      */
     async checkPositionsForLiquidations() {
         while (true) {
-            await this.handleLiquidationRound();
-            console.log("Completed liquidation round");
+            try {
+                await this.handleLiquidationRound();
+                console.log("Completed liquidation round");
+            } catch (e) {
+                console.error("Error processing a liquidation round:", e);
+            }
             await U.wasteTime(conf.liquidatorScanInterval);
         }
     }

--- a/controller/liquidator.js
+++ b/controller/liquidator.js
@@ -45,7 +45,11 @@ class Liquidator {
         console.log(Object.keys(this.liquidations).length + " positions need to be liquidated");
 
         for (let p in this.liquidations) {
-            const pos = this.liquidations[p];
+            // It's possible that something has changed in between of finding the position by the Scanner and calling
+            // this method. Thus, we fetch the loan again here.
+            const pos = await C.contractSovryn.methods.getLoan(p).call();
+            // TODO: check healthy position
+
             const token = pos.loanToken.toLowerCase() === conf.testTokenRBTC ? "rBtc" : pos.loanToken;
 
             //Position already in liquidation wallet-queue

--- a/controller/rollover.js
+++ b/controller/rollover.js
@@ -45,7 +45,10 @@ class Rollover {
         console.log("started checking expired positions");
 
         for (let p in this.positions) {
-            const position = this.positions[p];
+            // It's possible that something has changed in between of finding the position by the Scanner and calling
+            // this method. Thus, we fetch the loan again here.
+            const position = await C.contractSovryn.methods.getLoan(p).call();
+
             const amn = C.web3.utils.fromWei(position.collateral.toString(), "Ether");
 
             const collateralTokenAddress = position.collateralToken.toLowerCase();

--- a/controller/rollover.js
+++ b/controller/rollover.js
@@ -31,8 +31,12 @@ class Rollover {
      */
     async checkPositionsExpiration() {
         while (true) {
-            await this.handleRolloverRound();
-            console.log("Completed rollover");
+            try {
+                await this.handleRolloverRound();
+                console.log("Completed rollover");
+            } catch (e) {
+                console.error("Error processing a rollover round:", e);
+            }
             await U.wasteTime(conf.rolloverScanInterval);
         }
     }

--- a/controller/scanner.js
+++ b/controller/scanner.js
@@ -4,6 +4,7 @@
  * positions flagged for liquidation in "liquidations".
  */
 import C from './contract';
+import Liquidator from './liquidator';
 import U from '../util/helper';
 import conf from '../config/config';
 
@@ -102,7 +103,6 @@ class PositionScanner {
      * positions ready for liquidation to the liquidations queue
      */
     addPosition(loans) {
-        const maintenanceMarginBuffer = conf.maintenanceMarginBuffer || 0.95;
         for (let l of loans) {
             if (!l.loanId) continue;
 
@@ -110,11 +110,11 @@ class PositionScanner {
 
             if(l.currentMargin<l.maintenanceMargin*1.02) {
                 console.log("Margin call for  "+l.loanId+". Current margin: "+C.web3.utils.fromWei(l.currentMargin.toString(), "Ether"));
-                console.log("Liquidation will happen at: "+C.web3.utils.fromWei((l.maintenanceMargin*maintenanceMarginBuffer).toString(), "Ether"));
+                console.log("Liquidation will happen at: "+C.web3.utils.fromWei((Liquidator.getBufferedMaintenanceMargin(l)).toString(), "Ether"));
             }
 
             //If liquidating at the very edge we often get errors if the price bounces back
-            if(l.maxLiquidatable > 0 && l.currentMargin < (l.maintenanceMargin * maintenanceMarginBuffer)) {
+            if(Liquidator.isLiquidatable(l)) {
                 this.liquidations[l.loanId] = l;
             }
         }

--- a/controller/scanner.js
+++ b/controller/scanner.js
@@ -112,6 +112,7 @@ class PositionScanner {
                 console.log("Margin call for  "+l.loanId+". Current margin: "+C.web3.utils.fromWei(l.currentMargin.toString(), "Ether"));
                 console.log("Liquidation will happen at: "+C.web3.utils.fromWei((l.maintenanceMargin*maintenanceMarginBuffer).toString(), "Ether"));
             }
+
             //If liquidating at the very edge we often get errors if the price bounces back
             if(l.maxLiquidatable > 0 && l.currentMargin < (l.maintenanceMargin * maintenanceMarginBuffer)) {
                 this.liquidations[l.loanId] = l;

--- a/integration-tests/test/base/utils.js
+++ b/integration-tests/test/base/utils.js
@@ -84,3 +84,45 @@ export async function printAccountDetails({
         }
     }
 }
+
+export async function findContract(contractMap, address) {
+    for (let [ name, contract ] of Object.entries(contractMap)) {
+        //console.log(`Checking ${name}`)
+
+        //if (Array.isArray(contract)) {
+        //    const tmpMap = {};
+        //    contract.forEach((c, i) => {
+        //        tmpMap[`${name}[${i}]`] = c;
+        //    })
+        //    const tmp = findContract(tmpMap, address);
+        //    if (tmp) {
+        //        return tmp;
+        //    }
+        //    continue;
+        //}
+        let contractAddress;
+        if (typeof contract === "string") {
+            contractAddress = contract;
+        } else if (contract.address) {
+            contractAddress = contract.address;
+        } else {
+            //if (typeof contract === 'object') {
+            //    const tmpMap = {};
+            //    for(let [tmpName, tmpValue] of Object.entries(contract)) {
+            //        tmpMap[`${name}.${tmpName}`] = tmpValue;
+            //    }
+            //    const tmp = findContract(tmpMap, address);
+            //    if (tmp) {
+            //        return tmp;
+            //    }
+            //}
+            continue;
+        }
+        if (contractAddress.toLowerCase() === address.toLowerCase()) {
+            console.log(`Contract for ${address} is ${name}`);
+            return contract;
+        }
+    }
+    //console.log(`Contract not found for ${address}`);
+    return null;
+}


### PR DESCRIPTION
- "Refresh" loans just before doing liquidations and/or rollovers, to avoid race conditions when someone else already liquidated/rolled over
- Check that positions can be liquidated just before liquidations
- Add error handling to rollover and liquidation, so that if something goes wrong, it doesn't crash the whole Liquidation/rollover process

This is unit tested but not tested in practice.