### PR TITLE
Enable DLLR arbitrage on testnet

### DIFF
--- a/config/config_testnet.js
+++ b/config/config_testnet.js
@@ -31,7 +31,7 @@ export default {
     USDTToken: "0x4d5a316d23ebe168d8f887b4447bf8dbfa4901cc",
     BProToken: "0x4da7997a819bb46b6758b9102234c289dd2ad3bf",
     XUSDToken: "0xa9262cc3fb54ea55b1b0af00efca9416b8d59570",
-    ethsToken: "0x499bb1355b36adeb93706b08a897ce6022de6ac9",
+    ethsToken: "0x0fd0d8d78ce9299ee0e5676a8d51f938c234162c",
     sovToken: "0x6a9a07972d07e58f0daf5122d11e069288a375fb",
     dllrToken: "0x007b3aa69a846cb1f76b60b3088230a52d2a83ac",
     sovrynProtocolAdr: "0x25380305f223b32fdb844152abd2e82bc5ad99c3",

--- a/config/config_testnet.js
+++ b/config/config_testnet.js
@@ -33,6 +33,7 @@ export default {
     XUSDToken: "0xa9262cc3fb54ea55b1b0af00efca9416b8d59570",
     ethsToken: "0x499bb1355b36adeb93706b08a897ce6022de6ac9",
     sovToken: "0x6a9a07972d07e58f0daf5122d11e069288a375fb",
+    dllrToken: "0x007b3aa69a846cb1f76b60b3088230a52d2a83ac",
     sovrynProtocolAdr: "0x25380305f223b32fdb844152abd2e82bc5ad99c3",
     swapsImpl: "0x61172b53423e205a399640e5283e51fe60ec2256", //get price from amm/old execute swaps
     priceFeed: "0x7f38c422b99075f63c9c919ecd200df8d2cf5bd4", //get oracle price
@@ -42,7 +43,8 @@ export default {
         usdt: 100, // in usdt
         bpro: 0.01, // in bpro
         wrbtc: 0.01, // in wrbtc
-        xusd: 1000
+        xusd: 1000,
+        dllr: 1000
     },
     thresholdArbitrage: 0.1, //in %
     amountArbitrage: 0.05, //in rbtc
@@ -51,6 +53,7 @@ export default {
         rbtc: '1',
         default: '100000',
         xusd: '10000',
+        dllr: '10000',
     },
     errorBotTelegram: telegramBot,
     sovrynInternalTelegramId: -492690059,

--- a/controller/contract.js
+++ b/controller/contract.js
@@ -42,6 +42,7 @@ class Contract {
         this.contractTokenETHs = new this.web3.eth.Contract(abiTestToken, conf.ethsToken);
         this.contractTokenXUSD = new this.web3.eth.Contract(abiTestToken, conf.XUSDToken);
         this.contractTokenSOV = new this.web3.eth.Contract(abiTestToken, conf.sovToken);
+        this.contractTokenDLLR = conf.dllrToken ? new this.web3.eth.Contract(abiTestToken, conf.dllrToken) : null;
 
         this.tokenContractsByAddress = {}
         this.tokenContractsByAddress[conf.docToken.toLowerCase()] = this.contractTokenSUSD;
@@ -51,6 +52,9 @@ class Contract {
         this.tokenContractsByAddress[conf.ethsToken.toLowerCase()] = this.contractTokenETHs;
         this.tokenContractsByAddress[conf.XUSDToken.toLowerCase()] = this.contractTokenXUSD;
         this.tokenContractsByAddress[conf.sovToken.toLowerCase()] = this.contractTokenSOV;
+        if (conf.dllrToken) {
+            this.tokenContractsByAddress[conf.dllrToken.toLowerCase()] = this.contractTokenDLLR;
+        }
         this.tokenSymbolsByAddress = {}
         this.tokenSymbolsByAddress[conf.docToken.toLowerCase()] = "doc"
         this.tokenSymbolsByAddress[conf.testTokenRBTC.toLowerCase()] = "rbtc";
@@ -59,6 +63,9 @@ class Contract {
         this.tokenSymbolsByAddress[conf.ethsToken.toLowerCase()] = "eths";
         this.tokenSymbolsByAddress[conf.XUSDToken.toLowerCase()] = "xusd";
         this.tokenSymbolsByAddress[conf.sovToken.toLowerCase()] = "sov";
+        if (conf.dllrToken) {
+            this.tokenSymbolsByAddress[conf.dllrToken.toLowerCase()] = "dllr";
+        }
 
         this.contractSwaps = new this.web3.eth.Contract(abiSwaps, conf.swapsImpl);
         this.contractPriceFeed = new this.web3.eth.Contract(abiPriceFeed, conf.priceFeed);

--- a/controller/v2/arbitrage.js
+++ b/controller/v2/arbitrage.js
@@ -70,6 +70,7 @@ class ArbitrageV2 extends Arbitrage {
         else if(sourceCurrency === "bpro") sourceToken = conf.BProToken;
         else if(sourceCurrency === "xusd") sourceToken = conf.XUSDToken;
         else if(sourceCurrency === "eths") sourceToken = conf.ethsToken;
+        else if(sourceCurrency === "dllr") sourceToken = conf.dllrToken;
         else sourceToken = conf.testTokenRBTC;
 
         if(destCurrency === "doc") destToken = conf.docToken;
@@ -77,6 +78,7 @@ class ArbitrageV2 extends Arbitrage {
         else if(destCurrency === "bpro") destToken = conf.BProToken;
         else if(destCurrency === "xusd") destToken = conf.XUSDToken;
         else if(destCurrency === "eths") destToken = conf.ethsToken;
+        else if(destCurrency === "dllr") destToken = conf.dllrToken;
         else destToken = conf.testTokenRBTC;
 
         const minProfit = 0; // no profit enforced yet


### PR DESCRIPTION
Untested because PriceFeeds still uses the AMM price oracle on testnet